### PR TITLE
Switch site to dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,13 +48,13 @@
       }
     </style>
   </head>
-  <body
-    class="bg-gradient-to-b from-white via-naarm-50 to-naarm-100 text-gray-900 antialiased font-sans"
-  >
-    <!-- NAVBAR -->
-    <nav
-      class="fixed inset-x-0 top-0 z-50 border-b border-gray-200 bg-white/80 backdrop-blur shadow-sm"
+    <body
+      class="bg-gray-900 text-gray-100 antialiased font-sans"
     >
+    <!-- NAVBAR -->
+      <nav
+        class="fixed inset-x-0 top-0 z-50 border-b border-gray-800 bg-gray-900/80 backdrop-blur shadow-sm"
+      >
       <div class="mx-auto max-w-6xl px-4">
         <div class="flex h-16 items-center justify-between">
           <a href="#" class="flex items-center gap-2">
@@ -64,22 +64,22 @@
           <div class="hidden items-center gap-6 md:flex">
             <a
               href="#features"
-              class="text-sm transition-colors hover:text-naarm-700"
+                class="text-sm transition-colors hover:text-naarm-300"
               >Features</a
             >
             <a
               href="#how"
-              class="text-sm transition-colors hover:text-naarm-700"
+                class="text-sm transition-colors hover:text-naarm-300"
               >How it works</a
             >
             <a
               href="#faq"
-              class="text-sm transition-colors hover:text-naarm-700"
+                class="text-sm transition-colors hover:text-naarm-300"
               >FAQ</a
             >
             <a
               href="#contact"
-              class="text-sm transition-colors hover:text-naarm-700"
+                class="text-sm transition-colors hover:text-naarm-300"
               >Contact</a
             >
             <a href="#join" class="btn-primary text-sm">Join the waitlist</a>
@@ -111,18 +111,18 @@
         <div class="space-y-2 px-4 pb-4 pt-2">
           <a
             href="#features"
-            class="block transition-colors hover:text-naarm-700"
+              class="block transition-colors hover:text-naarm-300"
             >Features</a
           >
-          <a href="#how" class="block transition-colors hover:text-naarm-700"
+            <a href="#how" class="block transition-colors hover:text-naarm-300"
             >How it works</a
           >
-          <a href="#faq" class="block transition-colors hover:text-naarm-700"
+            <a href="#faq" class="block transition-colors hover:text-naarm-300"
             >FAQ</a
           >
           <a
             href="#contact"
-            class="block transition-colors hover:text-naarm-700"
+              class="block transition-colors hover:text-naarm-300"
             >Contact</a
           >
           <a href="#join" class="btn-primary block text-center"
@@ -137,15 +137,15 @@
       <div class="mx-auto max-w-6xl px-4">
         <div class="grid items-center gap-10 md:grid-cols-2">
           <div>
-            <h1 class="text-4xl font-extrabold tracking-tight md:text-5xl">
-              A weather forecast for
-              <span class="text-naarm-700">local culture</span>
-            </h1>
-            <p class="mt-4 text-lg text-gray-600">
-              An AI‑first, automated gig guide for Naarm/Melbourne. Dashboards
-              for booking agents; voice‑powered gig discovery for fans.
-            </p>
-            <ul class="mt-6 list-disc space-y-2 pl-5 text-gray-700">
+              <h1 class="text-4xl font-extrabold tracking-tight md:text-5xl">
+                A weather forecast for
+                <span class="text-naarm-300">local culture</span>
+              </h1>
+              <p class="mt-4 text-lg text-gray-400">
+                An AI‑first, automated gig guide for Naarm/Melbourne. Dashboards
+                for booking agents; voice‑powered gig discovery for fans.
+              </p>
+              <ul class="mt-6 list-disc space-y-2 pl-5 text-gray-300">
               <li>Interactive dashboards • maps • D3 genre plots</li>
               <li>AI crawling • clustering • poster OCR • artist bios</li>
               <li>
@@ -168,37 +168,37 @@
                   required
                   type="email"
                   placeholder="Enter your email"
-                  class="w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-naarm-600 focus:ring-naarm-200"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-gray-100 placeholder-gray-400 focus:border-naarm-500 focus:ring-naarm-500"
                 />
-                <button class="btn-primary" type="submit">
+              <button class="btn-primary" type="submit">
                   Get early access
                 </button>
               </form>
-              <p class="mt-2 text-xs text-gray-500">
-                No spam. Unsubscribe anytime.
-              </p>
+                <p class="mt-2 text-xs text-gray-400">
+                  No spam. Unsubscribe anytime.
+                </p>
             </div>
           </div>
           <div>
             <div
-              class="rounded-2xl border border-gray-200 bg-gradient-to-b from-white to-gray-50 p-4 shadow-sm"
-            >
+              class="rounded-2xl border border-gray-700 bg-gray-800 p-4 shadow-sm"
+              >
               <img
                 src="images/data.png"
                 alt="upset plot of music genre information"
                 class="h-72 w-full rounded-xl object-cover"
               />
               <div class="mt-4 grid grid-cols-2 gap-3 text-sm">
-                <div class="rounded-xl border p-3">
-                  <div class="font-medium">Dashboard</div>
-                  <div class="text-gray-600">Overview at a glance</div>
-                </div>
-                <div class="rounded-xl border p-3">
-                  <div class="font-medium">Voice service</div>
-                  <div class="text-gray-600">
-                    “What brutal gigs next weekend?”
+                  <div class="rounded-xl border border-gray-700 bg-gray-800 p-3">
+                    <div class="font-medium">Dashboard</div>
+                    <div class="text-gray-400">Overview at a glance</div>
                   </div>
-                </div>
+                  <div class="rounded-xl border border-gray-700 bg-gray-800 p-3">
+                    <div class="font-medium">Voice service</div>
+                    <div class="text-gray-400">
+                      “What brutal gigs next weekend?”
+                    </div>
+                  </div>
               </div>
             </div>
           </div>
@@ -209,44 +209,44 @@
     <!-- FEATURES -->
     <section id="features" class="py-24">
       <div class="mx-auto max-w-6xl px-4">
-        <h2 class="text-3xl font-bold">Built for bookers and fans</h2>
-        <p class="mt-2 max-w-2xl text-gray-600">
-          From fuzzy genre clustering to poster OCR, we turn fragmented event
-          data into usable tools and voice‑ready summaries.
-        </p>
+          <h2 class="text-3xl font-bold">Built for bookers and fans</h2>
+          <p class="mt-2 max-w-2xl text-gray-400">
+            From fuzzy genre clustering to poster OCR, we turn fragmented event
+            data into usable tools and voice‑ready summaries.
+          </p>
         <div class="mt-10 grid gap-6 md:grid-cols-3">
-          <div class="rounded-2xl border p-6 shadow-sm">
-            <h3 class="font-semibold">AI crawling</h3>
-            <p class="mt-2 text-gray-600">
-              Continuously scans venues, gig guides, ticketing sites, and
-              Instagram.
-            </p>
-          </div>
-          <div class="rounded-2xl border p-6 shadow-sm">
-            <h3 class="font-semibold">Genre clustering</h3>
-            <p class="mt-2 text-gray-600">
-              Fuzzy classification highlights cross‑scene collisions.
-            </p>
-          </div>
-          <div class="rounded-2xl border p-6 shadow-sm">
-            <h3 class="font-semibold">Poster OCR</h3>
-            <p class="mt-2 text-gray-600">
-              Extracts dates/lineups hidden in artwork.
-            </p>
-          </div>
+            <div class="rounded-2xl border border-gray-700 bg-gray-800 p-6 shadow-sm">
+              <h3 class="font-semibold">AI crawling</h3>
+              <p class="mt-2 text-gray-400">
+                Continuously scans venues, gig guides, ticketing sites, and
+                Instagram.
+              </p>
+            </div>
+            <div class="rounded-2xl border border-gray-700 bg-gray-800 p-6 shadow-sm">
+              <h3 class="font-semibold">Genre clustering</h3>
+              <p class="mt-2 text-gray-400">
+                Fuzzy classification highlights cross‑scene collisions.
+              </p>
+            </div>
+            <div class="rounded-2xl border border-gray-700 bg-gray-800 p-6 shadow-sm">
+              <h3 class="font-semibold">Poster OCR</h3>
+              <p class="mt-2 text-gray-400">
+                Extracts dates/lineups hidden in artwork.
+              </p>
+            </div>
         </div>
       </div>
     </section>
 
     <!-- FAQ (Flowbite accordion) -->
-    <section id="faq" class="border-t py-24">
+      <section id="faq" class="border-t border-gray-800 py-24">
       <div class="mx-auto max-w-3xl px-4">
         <h2 class="text-3xl font-bold">FAQ</h2>
         <div id="accordion-collapse" data-accordion="collapse" class="mt-6">
           <h3 id="faq-1">
             <button
               type="button"
-              class="flex w-full items-center justify-between rounded-lg border px-4 py-3 text-left"
+                class="flex w-full items-center justify-between rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-left"
               data-accordion-target="#faq-1-body"
               aria-expanded="false"
               aria-controls="faq-1-body"
@@ -269,16 +269,16 @@
             </button>
           </h3>
           <div id="faq-1-body" class="hidden" aria-labelledby="faq-1">
-            <div class="border-x border-b p-4 text-gray-600">
-              An AI‑first, automated gig guide for Naarm/Melbourne that serves
-              both booking agents and fans.
-            </div>
+              <div class="border-x border-b border-gray-700 bg-gray-800 p-4 text-gray-400">
+                An AI‑first, automated gig guide for Naarm/Melbourne that serves
+                both booking agents and fans.
+              </div>
           </div>
 
           <h3 id="faq-2" class="mt-3">
             <button
               type="button"
-              class="flex w-full items-center justify-between rounded-lg border px-4 py-3 text-left"
+                class="flex w-full items-center justify-between rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-left"
               data-accordion-target="#faq-2-body"
               aria-expanded="false"
               aria-controls="faq-2-body"
@@ -301,25 +301,25 @@
             </button>
           </h3>
           <div id="faq-2-body" class="hidden" aria-labelledby="faq-2">
-            <div class="border-x border-b p-4 text-gray-600">
-              Pop your email in the form above. We’ll reach out as soon as
-              pilots open.
-            </div>
+              <div class="border-x border-b border-gray-700 bg-gray-800 p-4 text-gray-400">
+                Pop your email in the form above. We’ll reach out as soon as
+                pilots open.
+              </div>
           </div>
         </div>
       </div>
     </section>
 
     <!-- CONTACT -->
-    <section id="contact" class="border-t py-16">
-      <div class="mx-auto max-w-3xl px-4 text-sm text-gray-600">
+      <section id="contact" class="border-t border-gray-800 py-16">
+        <div class="mx-auto max-w-3xl px-4 text-sm text-gray-400">
         <p>
           Contact:
-          <a
-            class="text-naarm-700 hover:underline"
-            href="mailto:gumballelectronics@gmail.com"
-            >gumballelectronics@gmail.com</a
-          >
+            <a
+              class="text-naarm-300 hover:underline"
+              href="mailto:gumballelectronics@gmail.com"
+              >gumballelectronics@gmail.com</a
+            >
           • 0416 735 582
         </p>
         <p class="mt-2">© <span id="year"></span> Music Naarm</p>


### PR DESCRIPTION
## Summary
- swap site styling to dark gray background and light gray text
- darken navigation, feature cards, FAQ, and contact sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68999fa1337883319beb533e56703bc1